### PR TITLE
Merge streamer and API into one process

### DIFF
--- a/mac/api_server.py
+++ b/mac/api_server.py
@@ -2,8 +2,8 @@
 """
 WRIT-FM Now Playing API
 
-Simple HTTP server that exposes the current track info.
-Reads from the now_playing.json file written by the streamer.
+HTTP server that exposes current track info, schedule, history, and more.
+Runs as a daemon thread inside the streamer process.
 """
 
 import http.server
@@ -11,6 +11,7 @@ import json
 import os
 import socketserver
 import subprocess
+import threading
 import time
 import urllib.parse
 import urllib.request
@@ -43,7 +44,6 @@ _discogs_cache: dict[str, dict | None] = {}
 _discogs_last_track: str | None = None
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_NOW_PLAYING_FILE = PROJECT_ROOT / "output" / "now_playing.json"
 MESSAGES_FILE = Path.home() / ".writ" / "messages.json"
 
 # Rate limiting for messages
@@ -51,13 +51,15 @@ MESSAGE_COOLDOWN = 300  # 5 minutes between messages per IP
 last_message_times: dict[str, float] = {}
 
 PORT = int(os.environ.get("WRIT_NOW_PLAYING_PORT", "8001"))
-NOW_PLAYING_FILE = Path(
-    os.environ.get("WRIT_NOW_PLAYING_FILE", str(DEFAULT_NOW_PLAYING_FILE))
-).expanduser()
 ICECAST_STATUS_URL = os.environ.get(
     "ICECAST_STATUS_URL",
     "http://localhost:8000/status-json.xsl",
 )
+
+# Shared state — set by start_api_thread()
+_track_info: dict = {}
+_encoder_getter = None
+_listener_fn = None
 
 # Server start time for uptime tracking
 SERVER_START_TIME = time.time()
@@ -167,18 +169,6 @@ class NowPlayingHandler(http.server.BaseHTTPRequestHandler):
         pass  # Suppress logging
 
 
-def get_listeners() -> int:
-    """Get listener count from local Icecast."""
-    try:
-        with urllib.request.urlopen(ICECAST_STATUS_URL, timeout=2) as response:
-            data = json.loads(response.read().decode())
-            source = data.get("icestats", {}).get("source", {})
-            return source.get("listeners", 0)
-    except:
-        pass
-    return 0
-
-
 def check_process(name: str) -> bool:
     """Check if process is running."""
     try:
@@ -198,7 +188,8 @@ def check_url(url: str, timeout: int = 2) -> bool:
 def get_health_status() -> dict:
     """Get comprehensive health status of all components."""
     icecast_ok = check_url(ICECAST_STATUS_URL)
-    streamer_ok = check_process("stream_gapless")
+    encoder = _encoder_getter() if _encoder_getter else None
+    streamer_ok = encoder is not None and encoder.poll() is None
     tunnel_ok = check_process("cloudflared")
     return {
         "status": "healthy" if icecast_ok and streamer_ok and tunnel_ok else "degraded",
@@ -207,7 +198,7 @@ def get_health_status() -> dict:
             "icecast": {"status": "up" if icecast_ok else "down"},
             "streamer": {"status": "up" if streamer_ok else "down"},
             "tunnel": {"status": "up" if tunnel_ok else "down"},
-            "api": {"status": "up"},  # We're responding
+            "api": {"status": "up"},
         },
         "uptime_seconds": int(time.time() - SERVER_START_TIME),
     }
@@ -218,13 +209,14 @@ def get_stats() -> dict:
     uptime = int(time.time() - SERVER_START_TIME)
     hours = uptime // 3600
     minutes = (uptime % 3600) // 60
+    listeners = _listener_fn() if _listener_fn else 0
 
     return {
         "uptime": f"{hours}h {minutes}m",
         "uptime_seconds": uptime,
         "tracks_played": TRACKS_PLAYED,
         "total_listeners_served": TOTAL_LISTENERS_SERVED,
-        "current_listeners": get_listeners(),
+        "current_listeners": listeners,
         "api_started": datetime.fromtimestamp(SERVER_START_TIME).isoformat(),
     }
 
@@ -307,12 +299,9 @@ def get_messages(limit: int = 20) -> list[dict]:
 
 
 def get_now_playing() -> dict:
-    """Read current track info from JSON file."""
-    try:
-        data = json.loads(NOW_PLAYING_FILE.read_text()) if NOW_PLAYING_FILE.exists() else {}
-    except:
-        data = {}
-    data["listeners"] = get_listeners()
+    """Read current track info from shared in-memory state."""
+    data = dict(_track_info)
+    data["listeners"] = _listener_fn() if _listener_fn else 0
     return data
 
 
@@ -475,25 +464,28 @@ class ReusableTCPServer(socketserver.TCPServer):
     allow_reuse_address = True
 
 
-def run():
-    with ReusableTCPServer(("", PORT), NowPlayingHandler) as httpd:
-        print(f"Now Playing API running on http://localhost:{PORT}/now-playing")
-        print(f"  /schedule - Current and upcoming shows")
-        print(f"  /discogs  - Current track's Discogs info (bumpers only)")
-        print(f"  /qr       - QR code for Discogs page (PNG)")
-        if DISCOGS_ENABLED:
-            if DISCOGS_HAS_CREDS:
-                print("Discogs lookup: enabled (credentials found)")
-            else:
-                print("Discogs lookup: disabled (no DISCOGS_TOKEN env var)")
-                print("  Set DISCOGS_TOKEN or DISCOGS_KEY+DISCOGS_SECRET")
-                print("  Get credentials at https://www.discogs.com/settings/developers")
-        else:
-            print("Discogs lookup: disabled (module not found)")
-        print(f"QR generation:  {'enabled' if QR_ENABLED else 'disabled (install qrcode)'}")
-        print("Ctrl+C to stop")
-        httpd.serve_forever()
+def start_api_thread(track_info: dict, encoder_getter, listener_fn) -> threading.Thread:
+    """Start the HTTP API server in a daemon thread.
 
+    Args:
+        track_info: Mutable dict shared with the streamer (mutated in-place).
+        encoder_getter: Callable returning the current encoder subprocess.
+        listener_fn: Callable returning the current listener count.
+    """
+    global _track_info, _encoder_getter, _listener_fn, SERVER_START_TIME
+    _track_info = track_info
+    _encoder_getter = encoder_getter
+    _listener_fn = listener_fn
+    SERVER_START_TIME = time.time()
 
-if __name__ == "__main__":
-    run()
+    def _serve():
+        try:
+            with ReusableTCPServer(("", PORT), NowPlayingHandler) as httpd:
+                httpd.serve_forever()
+        except OSError as e:
+            from stream_gapless import log
+            log(f"API server failed to start: {e}")
+
+    t = threading.Thread(target=_serve, daemon=True)
+    t.start()
+    return t

--- a/mac/bumper_daemon.sh
+++ b/mac/bumper_daemon.sh
@@ -3,7 +3,7 @@
 # Keeps each show at MIN_BUMPERS pre-generated tracks.
 # Runs as a launchd agent; safe to kill and restart anytime.
 
-RADIO_DIR="/Volumes/K3/agent-working-space/projects/active/2025-12-29-radio-station"
+RADIO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 MIN_BUMPERS=10
 SLEEP_STOCKED=300    # 5min between checks when all shows are full
 SLEEP_NO_SERVER=60   # 1min retry when music-gen.server is offline

--- a/mac/listener_daemon.sh
+++ b/mac/listener_daemon.sh
@@ -6,7 +6,7 @@
 # Typical turnaround: ~2-3 minutes from message to audio in the queue.
 # The streamer picks up new segments between its current playback items.
 
-RADIO_DIR="/Volumes/K3/agent-working-space/projects/active/2025-12-29-radio-station"
+RADIO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 MESSAGES_FILE="$HOME/.writ/messages.json"
 POLL_INTERVAL=30  # seconds between checks
 

--- a/mac/music_gen_client.py
+++ b/mac/music_gen_client.py
@@ -7,11 +7,12 @@ Server: github.com/kortexa-ai/music-gen.server (default: localhost:4009)
 
 import base64
 import json
+import os
 import urllib.error
 import urllib.request
 from pathlib import Path
 
-MUSIC_GEN_BASE_URL = "http://localhost:4009"
+MUSIC_GEN_BASE_URL = os.environ.get("MUSIC_GEN_URL", "http://localhost:4009")
 
 
 def is_server_available(base_url: str = MUSIC_GEN_BASE_URL, timeout: float = 2.0) -> bool:

--- a/mac/start_music_gen.sh
+++ b/mac/start_music_gen.sh
@@ -10,7 +10,11 @@
 
 set -euo pipefail
 
-MUSIC_GEN_DIR="/Volumes/K3/agent-working-space/projects/active/music-gen.server"
+MUSIC_GEN_DIR="${MUSIC_GEN_DIR:-$(cd "$(dirname "$0")/../../music-gen.server" 2>/dev/null && pwd || echo "")}"
+if [ -z "$MUSIC_GEN_DIR" ] || [ ! -d "$MUSIC_GEN_DIR" ]; then
+    echo "Warning: music-gen.server not found. Set MUSIC_GEN_DIR or clone it alongside this repo."
+    echo "  Expected: $(cd "$(dirname "$0")/../.." && pwd)/music-gen.server"
+fi
 RADIO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SESSION="writ"
 

--- a/mac/stream_gapless.py
+++ b/mac/stream_gapless.py
@@ -220,9 +220,11 @@ def update_now_playing(
     if caption is not None:
         new_info["ai_generated"] = True
         new_info["caption"] = caption
-    # Mutate in-place so the API thread's reference stays valid
-    current_track_info.clear()
+    # Atomic-ish update: overwrite all keys at once (no clear() gap)
     current_track_info.update(new_info)
+    for k in list(current_track_info):
+        if k not in new_info:
+            del current_track_info[k]
     for path in NOW_PLAYING_PATHS:
         try:
             write_json_atomic(path, current_track_info)

--- a/mac/stream_gapless.py
+++ b/mac/stream_gapless.py
@@ -206,9 +206,8 @@ def update_now_playing(
     segment_type: str | None = None,
     caption: str | None = None,
 ):
-    """Write current track info to JSON file."""
-    global current_track_info
-    current_track_info = {
+    """Update current track info in-memory and write to disk for external sync."""
+    new_info = {
         "track": track,
         "type": track_type,
         "host": host,
@@ -219,8 +218,11 @@ def update_now_playing(
         "listeners": get_listener_count(),
     }
     if caption is not None:
-        current_track_info["ai_generated"] = True
-        current_track_info["caption"] = caption
+        new_info["ai_generated"] = True
+        new_info["caption"] = caption
+    # Mutate in-place so the API thread's reference stays valid
+    current_track_info.clear()
+    current_track_info.update(new_info)
     for path in NOW_PLAYING_PATHS:
         try:
             write_json_atomic(path, current_track_info)
@@ -563,6 +565,11 @@ def run():
             log(f"Loaded schedule with {len(station_schedule.shows)} shows")
         except Exception as e:
             log(f"Schedule load failed, using fallback: {e}")
+
+    # Start embedded API server
+    from api_server import start_api_thread
+    start_api_thread(current_track_info, lambda: encoder_proc, get_listener_count)
+    log("API server started on port 8001")
 
     # Count talk segments
     talk_count = 0

--- a/mac/talk_daemon.sh
+++ b/mac/talk_daemon.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# WRIT-FM Talk Daemon — continuously stock talk segments
+# Checks segment counts per show, generates when low.
+# Each cycle generates for the show with the fewest segments.
+# Safe to kill and restart anytime.
+
+RADIO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MIN_SEGMENTS=6       # target segments per show
+BATCH_SIZE=2         # segments to generate per cycle
+SLEEP_STOCKED=600    # 10min when all shows are above minimum
+SLEEP_BETWEEN=30     # 30s pause between generation cycles
+
+ts() { date +%H:%M; }
+
+echo "[talk-daemon $(ts)] Starting. Target: ${MIN_SEGMENTS} segments/show, batch: ${BATCH_SIZE}"
+
+# Unset CLAUDECODE so Claude CLI works inside tmux
+unset CLAUDECODE
+
+while true; do
+    cd "$RADIO_DIR"
+
+    # Find the show with the fewest segments
+    lowest_show=""
+    lowest_count=999
+
+    for show_dir in output/talk_segments/*/; do
+        [ -d "$show_dir" ] || continue
+        show_id="$(basename "$show_dir")"
+        count=$(find "$show_dir" -name '*.wav' -o -name '*.mp3' -o -name '*.flac' | wc -l | tr -d ' ')
+
+        if (( count < lowest_count )); then
+            lowest_count=$count
+            lowest_show=$show_id
+        fi
+    done
+
+    # If no show directories exist, generate for all
+    if [ -z "$lowest_show" ]; then
+        echo "[talk-daemon $(ts)] No segment dirs found — generating for all shows"
+        uv run python mac/content_generator/talk_generator.py --all --count "$BATCH_SIZE" 2>&1
+        echo "[talk-daemon $(ts)] Done. Sleeping ${SLEEP_BETWEEN}s..."
+        sleep $SLEEP_BETWEEN
+        continue
+    fi
+
+    # If lowest is above minimum, everything is stocked
+    if (( lowest_count >= MIN_SEGMENTS )); then
+        echo "[talk-daemon $(ts)] All shows stocked (lowest: ${lowest_show} = ${lowest_count}). Sleeping ${SLEEP_STOCKED}s..."
+        sleep $SLEEP_STOCKED
+        continue
+    fi
+
+    echo "[talk-daemon $(ts)] ${lowest_show} has ${lowest_count}/${MIN_SEGMENTS} segments — generating ${BATCH_SIZE}..."
+    uv run python mac/content_generator/talk_generator.py --show "$lowest_show" --count "$BATCH_SIZE" 2>&1
+
+    echo "[talk-daemon $(ts)] Done. Sleeping ${SLEEP_BETWEEN}s..."
+    sleep $SLEEP_BETWEEN
+done

--- a/mac/watchdog.py
+++ b/mac/watchdog.py
@@ -46,7 +46,7 @@ COMPONENTS = {
     "tunnel": {
         "check_url": None,
         "process_name": "cloudflared",
-        "start_cmd": ["cloudflared", "tunnel", "run", "writ-radio"],
+        "start_cmd": ["cloudflared", "tunnel", "run", "wvoid-radio"],
         "critical": True,
     },
 }

--- a/mac/watchdog.py
+++ b/mac/watchdog.py
@@ -38,7 +38,7 @@ COMPONENTS = {
         "critical": True,
     },
     "streamer": {
-        "check_url": None,  # Check by process
+        "check_url": "http://localhost:8001/now-playing",
         "process_name": "stream_gapless",
         "start_cmd": ["uv", "run", "python", str(PROJECT_ROOT / "mac" / "stream_gapless.py")],
         "critical": True,
@@ -48,12 +48,6 @@ COMPONENTS = {
         "process_name": "cloudflared",
         "start_cmd": ["cloudflared", "tunnel", "run", "writ-radio"],
         "critical": True,
-    },
-    "api": {
-        "check_url": "http://localhost:8001/now-playing",
-        "process_name": "now_playing_server",
-        "start_cmd": ["uv", "run", "python", str(PROJECT_ROOT / "mac" / "now_playing_server.py")],
-        "critical": False,
     },
 }
 

--- a/mac/watchdog.py
+++ b/mac/watchdog.py
@@ -5,6 +5,7 @@ Monitors all radio components and auto-restarts on failure.
 Sends Pushover alerts when things go wrong.
 """
 
+import shutil
 import subprocess
 import urllib.request
 import json
@@ -12,6 +13,9 @@ import time
 import os
 from datetime import datetime
 from pathlib import Path
+
+# Derive all paths from project root (parent of mac/)
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 # Configuration
 CHECK_INTERVAL = 30  # seconds
@@ -22,18 +26,21 @@ LOG_FILE = Path("/tmp/writ_watchdog.log")
 PUSHOVER_USER = os.environ.get("PUSHOVER_USER", "")
 PUSHOVER_TOKEN = os.environ.get("PUSHOVER_TOKEN", "")
 
+# Find icecast binary: env var > PATH > common locations
+ICECAST_BIN = os.environ.get("ICECAST_BIN") or shutil.which("icecast") or "/opt/homebrew/opt/icecast/bin/icecast"
+
 # Component definitions
 COMPONENTS = {
     "icecast": {
         "check_url": "http://localhost:8000/status-json.xsl",
         "process_name": "icecast",
-        "start_cmd": ["/opt/homebrew/opt/icecast/bin/icecast", "-c", "/Volumes/K3/agent-working-space/projects/active/2025-12-29-radio-station/config/icecast.xml"],
+        "start_cmd": [ICECAST_BIN, "-c", str(PROJECT_ROOT / "config" / "icecast.xml")],
         "critical": True,
     },
     "streamer": {
         "check_url": None,  # Check by process
         "process_name": "stream_gapless",
-        "start_cmd": ["uv", "run", "python", "/Volumes/K3/agent-working-space/projects/active/2025-12-29-radio-station/mac/stream_gapless.py"],
+        "start_cmd": ["uv", "run", "python", str(PROJECT_ROOT / "mac" / "stream_gapless.py")],
         "critical": True,
     },
     "tunnel": {
@@ -45,7 +52,7 @@ COMPONENTS = {
     "api": {
         "check_url": "http://localhost:8001/now-playing",
         "process_name": "now_playing_server",
-        "start_cmd": ["uv", "run", "python", "/Volumes/K3/agent-working-space/projects/active/2025-12-29-radio-station/mac/now_playing_server.py"],
+        "start_cmd": ["uv", "run", "python", str(PROJECT_ROOT / "mac" / "now_playing_server.py")],
         "critical": False,
     },
 }

--- a/run_operator.sh
+++ b/run_operator.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Cron runs with a minimal PATH; ensure Homebrew-installed CLIs are available.
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.local/bin"
 
 cd "$(dirname "$0")"
 

--- a/writ
+++ b/writ
@@ -160,15 +160,11 @@ stop_one() {
 cmd_start() {
     local target="${1:-}"
     case "$target" in
-        ""|core)
-            log "Starting core..."
+        ""|core|all)
+            log "Starting WRIT-FM..."
             start_one icecast; start_one stream; start_one tunnel
             start_one music-gen; start_one bumpers; start_one talkgen; start_one listener
             echo ""; ok "WRIT-FM up. tmux attach -t $SESSION" ;;
-        all)
-            cmd_start core; echo ""
-            log "Starting content..."
-            start_one music-gen; start_one bumpers; start_one talkgen; start_one listener ;;
         content)
             log "Starting content..."
             start_one music-gen; start_one bumpers; start_one talkgen; start_one listener ;;

--- a/writ
+++ b/writ
@@ -164,7 +164,7 @@ cmd_start() {
         ""|core)
             log "Starting core..."
             start_one icecast; start_one stream; start_one api; start_one tunnel
-            start_one talkgen
+            start_one talkgen; start_one listener
             echo ""; ok "Core up. tmux attach -t $SESSION" ;;
         all)
             cmd_start core; echo ""

--- a/writ
+++ b/writ
@@ -13,7 +13,7 @@
 #
 # Components:
 #   Core (default):  icecast, stream, api, tunnel
-#   Content:         music-gen, bumpers, listener
+#   Content:         music-gen, bumpers, talkgen, listener
 #   Groups:          core, content, all
 # ──────────────────────────────────────────────────────────────
 set -euo pipefail
@@ -26,26 +26,26 @@ MUSIC_GEN_DIR="${MUSIC_GEN_DIR:-}"
 SESSION="writ"
 
 CORE_COMPONENTS=(icecast stream api tunnel)
-CONTENT_COMPONENTS=(music-gen bumpers listener)
+CONTENT_COMPONENTS=(music-gen bumpers talkgen listener)
 ALL_COMPONENTS=("${CORE_COMPONENTS[@]}" "${CONTENT_COMPONENTS[@]}")
 
 declare -A COMP_PORT=(
     [icecast]=8000 [stream]="" [api]=8001 [tunnel]=""
-    [music-gen]=4009 [bumpers]="" [listener]=""
+    [music-gen]=4009 [bumpers]="" [talkgen]="" [listener]=""
 )
 declare -A COMP_HEALTH_URL=(
     [icecast]="http://localhost:8000/status-json.xsl"
     [stream]="" [api]="http://localhost:8001/now-playing" [tunnel]=""
-    [music-gen]="http://localhost:4009/health" [bumpers]="" [listener]=""
+    [music-gen]="http://localhost:4009/health" [bumpers]="" [talkgen]="" [listener]=""
 )
 declare -A COMP_PGREP=(
     [icecast]="icecast" [stream]="stream_gapless" [api]="now_playing_server"
     [tunnel]="cloudflared.*wvoid" [music-gen]="music.gen"
-    [bumpers]="bumper_daemon" [listener]="listener_daemon"
+    [bumpers]="bumper_daemon" [talkgen]="talk_daemon" [listener]="listener_daemon"
 )
 declare -A COMP_WAIT=(
     [icecast]=30 [stream]=10 [api]=10 [tunnel]=10
-    [music-gen]=180 [bumpers]=10 [listener]=10
+    [music-gen]=180 [bumpers]=10 [talkgen]=10 [listener]=10
 )
 
 # ── Colors ───────────────────────────────────────────────────
@@ -114,6 +114,7 @@ get_start_cmd() {
                 { err "music-gen.server not found. Set MUSIC_GEN_DIR."; return 1; }
             echo "cd '$MUSIC_GEN_DIR' && LM_BACKEND=mlx PRELOAD_MODELS=1 ./run.sh" ;;
         bumpers)   echo "cd '$PROJECT_ROOT' && bash mac/bumper_daemon.sh" ;;
+        talkgen)   echo "cd '$PROJECT_ROOT' && unset CLAUDECODE && bash mac/talk_daemon.sh" ;;
         listener)  echo "cd '$PROJECT_ROOT' && unset CLAUDECODE && bash mac/listener_daemon.sh" ;;
     esac
 }
@@ -163,14 +164,15 @@ cmd_start() {
         ""|core)
             log "Starting core..."
             start_one icecast; start_one stream; start_one api; start_one tunnel
+            start_one talkgen
             echo ""; ok "Core up. tmux attach -t $SESSION" ;;
         all)
             cmd_start core; echo ""
             log "Starting content..."
-            start_one music-gen; start_one bumpers; start_one listener ;;
+            start_one music-gen; start_one bumpers; start_one talkgen; start_one listener ;;
         content)
             log "Starting content..."
-            start_one music-gen; start_one bumpers; start_one listener ;;
+            start_one music-gen; start_one bumpers; start_one talkgen; start_one listener ;;
         *)  validate_component "$target"; start_one "$target" ;;
     esac
 }
@@ -180,11 +182,11 @@ cmd_stop() {
     case "$target" in
         ""|all)
             log "Stopping all..."
-            for c in listener bumpers music-gen tunnel api stream icecast; do stop_one "$c"; done
+            for c in listener talkgen bumpers music-gen tunnel api stream icecast; do stop_one "$c"; done
             local n; n=$(tmux list-windows -t "$SESSION" 2>/dev/null | wc -l | tr -d ' ')
             (( n <= 1 )) && { tmux kill-session -t "$SESSION" 2>/dev/null || true; } ;;
         core)    for c in tunnel api stream icecast; do stop_one "$c"; done ;;
-        content) for c in listener bumpers music-gen; do stop_one "$c"; done ;;
+        content) for c in listener talkgen bumpers music-gen; do stop_one "$c"; done ;;
         *)       validate_component "$target"; stop_one "$target" ;;
     esac
 }
@@ -279,7 +281,7 @@ cmd_help() {
   writ attach [component]     Attach to tmux window
   writ generate <talk|music>  Generate content (foreground)
 
-  Components:  icecast  stream  api  tunnel  music-gen  bumpers  listener
+  Components:  icecast  stream  api  tunnel  music-gen  bumpers  talkgen  listener
   Groups:      core  content  all
 
 EOF

--- a/writ
+++ b/writ
@@ -1,0 +1,300 @@
+#!/opt/homebrew/bin/bash
+# ──────────────────────────────────────────────────────────────
+# writ — WRIT-FM Radio Station CLI
+#
+# Usage:
+#   writ start [component]     Start core components or a specific one
+#   writ stop [component]      Stop everything or a specific component
+#   writ restart [component]   Restart
+#   writ status                Show what's running
+#   writ logs <component> [-f] Tail logs (-f to attach live)
+#   writ attach [component]    Attach to tmux window
+#   writ generate <talk|music> Run content generation (foreground)
+#
+# Components:
+#   Core (default):  icecast, stream, api, tunnel
+#   Content:         music-gen, bumpers, listener
+#   Groups:          core, content, all
+# ──────────────────────────────────────────────────────────────
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+MUSIC_GEN_DIR="${MUSIC_GEN_DIR:-}"
+[[ -z "$MUSIC_GEN_DIR" && -d "$PROJECT_ROOT/../music-gen.server" ]] && \
+    MUSIC_GEN_DIR="$(cd "$PROJECT_ROOT/../music-gen.server" && pwd)"
+
+SESSION="writ"
+
+CORE_COMPONENTS=(icecast stream api tunnel)
+CONTENT_COMPONENTS=(music-gen bumpers listener)
+ALL_COMPONENTS=("${CORE_COMPONENTS[@]}" "${CONTENT_COMPONENTS[@]}")
+
+declare -A COMP_PORT=(
+    [icecast]=8000 [stream]="" [api]=8001 [tunnel]=""
+    [music-gen]=4009 [bumpers]="" [listener]=""
+)
+declare -A COMP_HEALTH_URL=(
+    [icecast]="http://localhost:8000/status-json.xsl"
+    [stream]="" [api]="http://localhost:8001/now-playing" [tunnel]=""
+    [music-gen]="http://localhost:4009/health" [bumpers]="" [listener]=""
+)
+declare -A COMP_PGREP=(
+    [icecast]="icecast" [stream]="stream_gapless" [api]="now_playing_server"
+    [tunnel]="cloudflared.*wvoid" [music-gen]="music.gen"
+    [bumpers]="bumper_daemon" [listener]="listener_daemon"
+)
+declare -A COMP_WAIT=(
+    [icecast]=30 [stream]=10 [api]=10 [tunnel]=10
+    [music-gen]=180 [bumpers]=10 [listener]=10
+)
+
+# ── Colors ───────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; DIM='\033[2m'; NC='\033[0m'
+
+log()   { echo -e "${DIM}[$(date +%H:%M:%S)]${NC} $*"; }
+ok()    { echo -e "  ${GREEN}✓${NC} $*"; }
+warn()  { echo -e "  ${YELLOW}!${NC} $*"; }
+err()   { echo -e "  ${RED}✗${NC} $*" >&2; }
+
+# ── tmux helpers ─────────────────────────────────────────────
+
+ensure_session() {
+    tmux has-session -t "$SESSION" 2>/dev/null || \
+        tmux new-session -d -s "$SESSION" -n "_scratch"
+}
+
+ensure_window() {
+    ensure_session
+    tmux list-windows -t "$SESSION" -F "#{window_name}" 2>/dev/null \
+        | grep -qx "$1" || tmux new-window -t "$SESSION" -n "$1"
+}
+
+window_exists() {
+    tmux list-windows -t "$SESSION" -F "#{window_name}" 2>/dev/null \
+        | grep -qx "$1"
+}
+
+send_cmd() { local w="$1"; shift; tmux send-keys -t "$SESSION:$w" "$*" Enter; }
+
+# ── health checks ────────────────────────────────────────────
+
+check_port()    { curl -sf --max-time 3 "$1" >/dev/null 2>&1; }
+check_process() { pgrep -f "$1" >/dev/null 2>&1; }
+
+is_healthy() {
+    local url="${COMP_HEALTH_URL[$1]}" pat="${COMP_PGREP[$1]}"
+    if [[ -n "$url" ]]; then check_port "$url"; else check_process "$pat"; fi
+}
+
+wait_for_healthy() {
+    local comp="$1" timeout="${2:-${COMP_WAIT[$1]}}" elapsed=0
+    while (( elapsed < timeout )); do
+        is_healthy "$comp" && return 0
+        sleep 2; elapsed=$((elapsed + 2)); printf "."
+    done
+    echo ""; return 1
+}
+
+validate_component() {
+    for c in "${ALL_COMPONENTS[@]}"; do [[ "$c" == "$1" ]] && return 0; done
+    err "Unknown component: $1  (valid: ${ALL_COMPONENTS[*]})"; exit 1
+}
+
+# ── start / stop ─────────────────────────────────────────────
+
+get_start_cmd() {
+    case "$1" in
+        icecast)   echo "/opt/homebrew/bin/icecast -c '$PROJECT_ROOT/config/icecast.xml'" ;;
+        stream)    echo "cd '$PROJECT_ROOT' && uv run python mac/stream_gapless.py" ;;
+        api)       echo "cd '$PROJECT_ROOT' && uv run python mac/now_playing_server.py" ;;
+        tunnel)    echo "cloudflared tunnel run wvoid-radio" ;;
+        music-gen)
+            [[ -z "$MUSIC_GEN_DIR" || ! -d "$MUSIC_GEN_DIR" ]] && \
+                { err "music-gen.server not found. Set MUSIC_GEN_DIR."; return 1; }
+            echo "cd '$MUSIC_GEN_DIR' && LM_BACKEND=mlx PRELOAD_MODELS=1 ./run.sh" ;;
+        bumpers)   echo "cd '$PROJECT_ROOT' && bash mac/bumper_daemon.sh" ;;
+        listener)  echo "cd '$PROJECT_ROOT' && unset CLAUDECODE && bash mac/listener_daemon.sh" ;;
+    esac
+}
+
+start_one() {
+    local comp="$1"
+
+    if is_healthy "$comp"; then ok "$comp already running"; return 0; fi
+
+    # dependency checks
+    case "$comp" in
+        stream)  is_healthy icecast   || { err "start icecast first"; return 1; } ;;
+        bumpers) is_healthy music-gen || { err "start music-gen first"; return 1; } ;;
+    esac
+
+    local cmd; cmd="$(get_start_cmd "$comp")" || return 1
+    ensure_window "$comp"
+    send_cmd "$comp" "$cmd"
+
+    printf "  Starting $comp "
+    if wait_for_healthy "$comp"; then
+        ok "$comp UP"; return 0
+    else
+        warn "$comp sent (may still be loading)"; return 0
+    fi
+}
+
+stop_one() {
+    local comp="$1" pat="${COMP_PGREP[$1]}"
+
+    if ! window_exists "$comp" && ! check_process "$pat"; then
+        ok "$comp already stopped"; return 0
+    fi
+
+    window_exists "$comp" && { tmux send-keys -t "$SESSION:$comp" C-c 2>/dev/null || true; sleep 2; }
+    check_process "$pat" && { pkill -f "$pat" 2>/dev/null || true; sleep 1; }
+    window_exists "$comp" && { tmux kill-window -t "$SESSION:$comp" 2>/dev/null || true; }
+
+    ok "$comp stopped"
+}
+
+# ── subcommands ──────────────────────────────────────────────
+
+cmd_start() {
+    local target="${1:-}"
+    case "$target" in
+        ""|core)
+            log "Starting core..."
+            start_one icecast; start_one stream; start_one api; start_one tunnel
+            echo ""; ok "Core up. tmux attach -t $SESSION" ;;
+        all)
+            cmd_start core; echo ""
+            log "Starting content..."
+            start_one music-gen; start_one bumpers; start_one listener ;;
+        content)
+            log "Starting content..."
+            start_one music-gen; start_one bumpers; start_one listener ;;
+        *)  validate_component "$target"; start_one "$target" ;;
+    esac
+}
+
+cmd_stop() {
+    local target="${1:-}"
+    case "$target" in
+        ""|all)
+            log "Stopping all..."
+            for c in listener bumpers music-gen tunnel api stream icecast; do stop_one "$c"; done
+            local n; n=$(tmux list-windows -t "$SESSION" 2>/dev/null | wc -l | tr -d ' ')
+            (( n <= 1 )) && { tmux kill-session -t "$SESSION" 2>/dev/null || true; } ;;
+        core)    for c in tunnel api stream icecast; do stop_one "$c"; done ;;
+        content) for c in listener bumpers music-gen; do stop_one "$c"; done ;;
+        *)       validate_component "$target"; stop_one "$target" ;;
+    esac
+}
+
+cmd_restart() {
+    local target="${1:-}"
+    if [[ -z "$target" ]]; then cmd_stop; sleep 1; cmd_start
+    else validate_component "$target"; stop_one "$target"; sleep 1; start_one "$target"; fi
+}
+
+cmd_status() {
+    echo ""
+    echo -e "  ${BOLD}WRIT-FM${NC}"
+    echo "  ────────────────────────────────────────────"
+    printf "  ${BOLD}%-14s %-8s %-6s %-16s${NC}\n" "COMPONENT" "STATUS" "PORT" "WINDOW"
+    echo "  ────────────────────────────────────────────"
+
+    local core_up=0 content_up=0
+
+    for comp in "${ALL_COMPONENTS[@]}"; do
+        local port="${COMP_PORT[$comp]:-"-"}"; [[ -z "$port" ]] && port="-"
+        local st sc win
+
+        if is_healthy "$comp"; then
+            st="UP"; sc="$GREEN"; win="$SESSION:$comp"
+            for c in "${CORE_COMPONENTS[@]}"; do [[ "$c" == "$comp" ]] && core_up=$((core_up+1)); done
+            for c in "${CONTENT_COMPONENTS[@]}"; do [[ "$c" == "$comp" ]] && content_up=$((content_up+1)); done
+        else
+            st="DOWN"; sc="$RED"; win="-"
+        fi
+        printf "  %-14s ${sc}%-8s${NC} %-6s %-16s\n" "$comp" "$st" "$port" "$win"
+    done
+
+    echo "  ────────────────────────────────────────────"
+    echo -e "  Core: ${BOLD}${core_up}/${#CORE_COMPONENTS[@]}${NC}  Content: ${BOLD}${content_up}/${#CONTENT_COMPONENTS[@]}${NC}"
+    echo ""
+}
+
+cmd_logs() {
+    local comp="${1:-}"; [[ -z "$comp" ]] && { err "Usage: writ logs <component> [-f]"; exit 1; }
+    validate_component "$comp"
+    window_exists "$comp" || { err "$comp has no active window"; exit 1; }
+
+    if [[ "${2:-}" == "-f" || "${2:-}" == "--follow" ]]; then
+        exec tmux attach -t "$SESSION:$comp"
+    else
+        tmux capture-pane -t "$SESSION:$comp" -p -S -100
+    fi
+}
+
+cmd_attach() {
+    local comp="${1:-}"
+    if [[ -z "$comp" ]]; then exec tmux attach -t "$SESSION"
+    else validate_component "$comp"; exec tmux attach -t "$SESSION:$comp"; fi
+}
+
+cmd_generate() {
+    local type="${1:-}"; shift 2>/dev/null || true
+    case "$type" in
+        talk)
+            log "Generating talk segments..."
+            cd "$PROJECT_ROOT"
+            exec uv run python mac/content_generator/talk_generator.py ${@:---all --count 3} ;;
+        music|bumper|bumpers)
+            is_healthy music-gen || warn "music-gen.server not running"
+            cd "$PROJECT_ROOT"
+            exec uv run python mac/content_generator/music_bumper_generator.py ${@:---all --min 10} ;;
+        status)
+            cd "$PROJECT_ROOT"
+            uv run python mac/content_generator/talk_generator.py --status 2>/dev/null
+            uv run python mac/content_generator/music_bumper_generator.py --status 2>/dev/null ;;
+        *)
+            echo "Usage: writ generate <talk|music|status> [args...]"
+            echo "  writ generate talk                          # 3 per show"
+            echo "  writ generate talk --show midnight_signal   # specific show"
+            echo "  writ generate music                         # stock bumpers"
+            echo "  writ generate status                        # show counts"
+            exit 1 ;;
+    esac
+}
+
+cmd_help() {
+    cat <<'EOF'
+
+  writ — WRIT-FM Radio Station CLI
+
+  writ start [component]      Start core or a specific component
+  writ stop [component]       Stop all or a specific component
+  writ restart [component]    Restart
+  writ status                 Health check all components
+  writ logs <component> [-f]  Show logs (-f for live)
+  writ attach [component]     Attach to tmux window
+  writ generate <talk|music>  Generate content (foreground)
+
+  Components:  icecast  stream  api  tunnel  music-gen  bumpers  listener
+  Groups:      core  content  all
+
+EOF
+}
+
+# ── main ─────────────────────────────────────────────────────
+cmd="${1:-help}"; shift 2>/dev/null || true
+case "$cmd" in
+    start)   cmd_start "$@" ;;
+    stop)    cmd_stop "$@" ;;
+    restart) cmd_restart "$@" ;;
+    status)  cmd_status ;;
+    logs)    cmd_logs "$@" ;;
+    attach)  cmd_attach "$@" ;;
+    generate) cmd_generate "$@" ;;
+    help|--help|-h) cmd_help ;;
+    *)       err "Unknown: $cmd"; cmd_help; exit 1 ;;
+esac

--- a/writ
+++ b/writ
@@ -12,7 +12,7 @@
 #   writ generate <talk|music> Run content generation (foreground)
 #
 # Components:
-#   Core (default):  icecast, stream, api, tunnel
+#   Core (default):  icecast, stream, tunnel
 #   Content:         music-gen, bumpers, talkgen, listener
 #   Groups:          core, content, all
 # ──────────────────────────────────────────────────────────────
@@ -25,26 +25,26 @@ MUSIC_GEN_DIR="${MUSIC_GEN_DIR:-}"
 
 SESSION="writ"
 
-CORE_COMPONENTS=(icecast stream api tunnel)
+CORE_COMPONENTS=(icecast stream tunnel)
 CONTENT_COMPONENTS=(music-gen bumpers talkgen listener)
 ALL_COMPONENTS=("${CORE_COMPONENTS[@]}" "${CONTENT_COMPONENTS[@]}")
 
 declare -A COMP_PORT=(
-    [icecast]=8000 [stream]="" [api]=8001 [tunnel]=""
+    [icecast]=8000 [stream]=8001 [tunnel]=""
     [music-gen]=4009 [bumpers]="" [talkgen]="" [listener]=""
 )
 declare -A COMP_HEALTH_URL=(
     [icecast]="http://localhost:8000/status-json.xsl"
-    [stream]="" [api]="http://localhost:8001/now-playing" [tunnel]=""
+    [stream]="http://localhost:8001/now-playing" [tunnel]=""
     [music-gen]="http://localhost:4009/health" [bumpers]="" [talkgen]="" [listener]=""
 )
 declare -A COMP_PGREP=(
-    [icecast]="icecast" [stream]="stream_gapless" [api]="now_playing_server"
+    [icecast]="icecast" [stream]="stream_gapless"
     [tunnel]="cloudflared.*wvoid" [music-gen]="music.gen"
     [bumpers]="bumper_daemon" [talkgen]="talk_daemon" [listener]="listener_daemon"
 )
 declare -A COMP_WAIT=(
-    [icecast]=30 [stream]=10 [api]=10 [tunnel]=10
+    [icecast]=30 [stream]=10 [tunnel]=10
     [music-gen]=180 [bumpers]=10 [talkgen]=10 [listener]=10
 )
 
@@ -107,7 +107,6 @@ get_start_cmd() {
     case "$1" in
         icecast)   echo "/opt/homebrew/bin/icecast -c '$PROJECT_ROOT/config/icecast.xml'" ;;
         stream)    echo "cd '$PROJECT_ROOT' && uv run python mac/stream_gapless.py" ;;
-        api)       echo "cd '$PROJECT_ROOT' && uv run python mac/now_playing_server.py" ;;
         tunnel)    echo "cloudflared tunnel run wvoid-radio" ;;
         music-gen)
             [[ -z "$MUSIC_GEN_DIR" || ! -d "$MUSIC_GEN_DIR" ]] && \
@@ -163,7 +162,7 @@ cmd_start() {
     case "$target" in
         ""|core)
             log "Starting core..."
-            start_one icecast; start_one stream; start_one api; start_one tunnel
+            start_one icecast; start_one stream; start_one tunnel
             start_one music-gen; start_one bumpers; start_one talkgen; start_one listener
             echo ""; ok "WRIT-FM up. tmux attach -t $SESSION" ;;
         all)
@@ -182,10 +181,10 @@ cmd_stop() {
     case "$target" in
         ""|all)
             log "Stopping all..."
-            for c in listener talkgen bumpers music-gen tunnel api stream icecast; do stop_one "$c"; done
+            for c in listener talkgen bumpers music-gen tunnel stream icecast; do stop_one "$c"; done
             local n; n=$(tmux list-windows -t "$SESSION" 2>/dev/null | wc -l | tr -d ' ')
             (( n <= 1 )) && { tmux kill-session -t "$SESSION" 2>/dev/null || true; } ;;
-        core)    for c in tunnel api stream icecast; do stop_one "$c"; done ;;
+        core)    for c in tunnel stream icecast; do stop_one "$c"; done ;;
         content) for c in listener talkgen bumpers music-gen; do stop_one "$c"; done ;;
         *)       validate_component "$target"; stop_one "$target" ;;
     esac
@@ -281,7 +280,7 @@ cmd_help() {
   writ attach [component]     Attach to tmux window
   writ generate <talk|music>  Generate content (foreground)
 
-  Components:  icecast  stream  api  tunnel  music-gen  bumpers  talkgen  listener
+  Components:  icecast  stream  tunnel  music-gen  bumpers  talkgen  listener
   Groups:      core  content  all
 
 EOF

--- a/writ
+++ b/writ
@@ -164,8 +164,8 @@ cmd_start() {
         ""|core)
             log "Starting core..."
             start_one icecast; start_one stream; start_one api; start_one tunnel
-            start_one talkgen; start_one listener
-            echo ""; ok "Core up. tmux attach -t $SESSION" ;;
+            start_one music-gen; start_one bumpers; start_one talkgen; start_one listener
+            echo ""; ok "WRIT-FM up. tmux attach -t $SESSION" ;;
         all)
             cmd_start core; echo ""
             log "Starting content..."


### PR DESCRIPTION
## Summary

- Streamer and API now run as a single process — API serves from a daemon thread reading shared in-memory state instead of `now_playing.json` on disk
- `now_playing_server.py` → `api_server.py` as an embeddable module with `start_api_thread()`
- `api` removed as a separate component from `writ` CLI and watchdog
- Disk write to `now_playing.json` preserved for GitHub Pages sync

## Test plan

- [ ] `uv run python mac/stream_gapless.py` starts both streamer and API
- [ ] `curl http://localhost:8001/now-playing` returns track info from memory
- [ ] `curl http://localhost:8001/health` shows streamer status without pgrep
- [ ] `writ status` shows `stream` as UP (no `api` row)
- [ ] `output/now_playing.json` still written for external consumers
- [ ] Killing the process stops both streamer and API (daemon thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)