### PR TITLE
docs: add tmux to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ WRIT-FM is a music-forward internet radio station where:
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install system dependencies (macOS)
-brew install icecast ffmpeg ezstream vorbis-tools
+brew install tmux icecast ffmpeg ezstream vorbis-tools
 
 # Set up Python environment
 uv sync


### PR DESCRIPTION
## Summary

The Quick Start brew install line in `README.md` was missing `tmux`, but the `writ` CLI (which the quickstart tells you to run) uses tmux to manage every component. On a fresh macOS install, following the README and then running `./writ start` fails immediately with:

```
./writ: line 97: tmux: command not found
```

## Diff

```diff
-brew install icecast ffmpeg ezstream vorbis-tools
+brew install tmux icecast ffmpeg ezstream vorbis-tools
```

## Scope

Only `README.md` was changed — no other files were touched.