### PR TITLE
Add Chatterbox and Voxtral TTS engines alongside Kokoro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,12 @@ __pycache__/
 # Chatterbox venv (separate from main)
 mac/chatterbox/.venv/
 
+# Voxtral venv (separate from main)
+mac/voxtral/.venv/
+
 # Output files (generated content — never commit)
 output/segments/
+output/tts-test/
 output/talk_segments/
 output/music_bumpers/
 output/scripts/

--- a/README.md
+++ b/README.md
@@ -64,12 +64,64 @@ uv sync
 
 ### 2. Set up TTS
 
+WRIT-FM ships three pluggable TTS engines. Each engine lives in its own venv so
+their PyTorch / MLX dependencies don't fight each other. Set up the one(s) you
+want — Kokoro is the default and is required for the out-of-the-box config.
+
 ```bash
-cd mac/kokoro
-uv venv
-uv pip install kokoro soundfile
-# Downloads ~200MB model on first run
+# Kokoro — fast, default, ~200MB on first run
+cd mac/kokoro && uv venv && uv pip install kokoro soundfile && cd ../..
+
+# Chatterbox (Resemble AI) — slower, supports voice cloning from a short reference WAV.
+# setuptools<81 is required: chatterbox's `perth` watermarker imports pkg_resources,
+# which setuptools 81+ removed. Without the pin you'll hit
+# "'NoneType' object is not callable" on first load.
+cd mac/chatterbox && uv venv && uv pip install chatterbox-tts soundfile torch torchaudio 'setuptools<81' && cd ../..
+
+# Voxtral (Mistral 4B, multilingual) — Apple Silicon path via MLX.
+# mistral-common[audio] is required for Voxtral's tekken tokenizer.
+cd mac/voxtral && uv venv && uv pip install mlx-audio soundfile 'mistral-common[audio]' && cd ../..
 ```
+
+Pick the active engine per station in `config/stations.yaml`:
+
+```yaml
+stations:
+  writ-fm:
+    tts_engine: kokoro   # kokoro | chatterbox | voxtral
+```
+
+Or override at runtime:
+
+```bash
+WRIT_TTS_ENGINE=chatterbox ./writ generate talk
+```
+
+A/B test all three on the same line:
+
+```bash
+./writ tts-test all "Hello from the frequency between frequencies."
+./writ tts-test chatterbox "Test the cloned voice" --voice samples/my_voice.wav
+./writ tts-test voxtral "Bonjour le monde" --voice casual_female
+# Outputs land in output/tts-test/.
+```
+
+**Per-engine voice mapping in `config/schedule.yaml`** — extend any `voice:`
+field from a single Kokoro voice id to a per-engine dict so each engine picks
+the right voice/sample without you reshuffling configs:
+
+```yaml
+shows:
+  midnight_signal:
+    voices:
+      host:
+        kokoro: am_michael
+        chatterbox: samples/host_clone.wav   # reference WAV for voice cloning
+        voxtral: neutral_male
+```
+
+The legacy single-string form (`host: am_michael`) still works and is treated
+as the Kokoro voice; non-Kokoro engines fall back to their built-in defaults.
 
 ### 3. Configure
 

--- a/config/stations.yaml
+++ b/config/stations.yaml
@@ -3,6 +3,10 @@ default_station: writ-fm
 stations:
   writ-fm:
     call_sign: WRIT-FM
+    # tts_engine selects the speech synthesis backend per station.
+    # Options: kokoro (default, fast), chatterbox (Resemble AI, voice cloning),
+    # voxtral (Mistral 4B, multilingual). Override at runtime with WRIT_TTS_ENGINE.
+    tts_engine: kokoro
     agent:
       kind: claude
       command: claude
@@ -25,6 +29,7 @@ stations:
 
   klod-fm:
     call_sign: KLOD-FM
+    tts_engine: kokoro
     agent:
       kind: claude
       command: claude
@@ -45,6 +50,7 @@ stations:
 
   cdex-fm:
     call_sign: CDEX-FM
+    tts_engine: kokoro
     agent:
       kind: codex
       command: codex

--- a/mac/chatterbox/tts.py
+++ b/mac/chatterbox/tts.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+WRIT-FM Chatterbox TTS Module
+
+Resemble AI's Chatterbox (0.5B params). Supports voice cloning from a short
+reference WAV. Slower than Kokoro but more expressive and clone-capable.
+
+Setup:
+    cd mac/chatterbox
+    uv venv
+    uv pip install chatterbox-tts soundfile torch torchaudio 'setuptools<81'
+
+Apple Silicon: torch picks up MPS automatically; this script selects mps if
+torch.backends.mps.is_available() is True.
+
+Note: setuptools<81 is required because Chatterbox's `perth` watermarker
+imports `pkg_resources`, which setuptools 81+ removed. With newer setuptools
+the watermarker silently fails to import and `ChatterboxTTS.__init__` blows
+up with "'NoneType' object is not callable".
+
+Usage:
+    python tts.py "Hello world" -o out.wav
+    python tts.py "Hello world" -o out.wav --voice path/to/reference.wav
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+CHATTERBOX_DIR = Path(__file__).parent
+VENV_PYTHON = CHATTERBOX_DIR / ".venv" / "bin" / "python"
+
+# Chatterbox has no named voices — it's clone-from-reference. The default
+# uses Chatterbox's built-in baseline voice.
+DEFAULT_VOICE = ""
+
+
+def setup_venv():
+    """Create and set up the chatterbox venv if it doesn't exist."""
+    venv_dir = CHATTERBOX_DIR / ".venv"
+    if not venv_dir.exists():
+        print("Setting up Chatterbox venv...")
+        subprocess.run(["uv", "venv"], cwd=CHATTERBOX_DIR, check=True)
+        subprocess.run(
+            ["uv", "pip", "install", "chatterbox-tts", "soundfile", "torch", "torchaudio", "setuptools<81"],
+            cwd=CHATTERBOX_DIR,
+            check=True,
+        )
+        print("Chatterbox venv ready")
+    return VENV_PYTHON.exists()
+
+
+def render_speech(
+    text: str,
+    output_path: Path,
+    voice: str = DEFAULT_VOICE,
+    exaggeration: float = 0.5,
+    cfg_weight: float = 0.5,
+) -> bool:
+    """
+    Render text to speech using Chatterbox TTS.
+
+    Args:
+        text: The text to speak.
+        output_path: Where to save the WAV file.
+        voice: Path to a reference WAV for voice cloning, or "" for the
+            default Chatterbox voice.
+        exaggeration: Emotion intensity 0.0-1.0 (0.5 = neutral, higher = more expressive).
+        cfg_weight: Classifier-free guidance weight 0.0-1.0.
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    if not VENV_PYTHON.exists():
+        if not setup_venv():
+            print("Failed to set up Chatterbox venv")
+            return False
+
+    # Subprocess runs with cwd=CHATTERBOX_DIR; resolve so relative paths still work.
+    output_path = Path(output_path).resolve()
+    # Escape text for embedding in Python string literal
+    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+    escaped_voice = voice.replace("\\", "\\\\").replace('"', '\\"') if voice else ""
+
+    tts_script = f'''
+import warnings
+warnings.filterwarnings("ignore")
+
+import torch
+import torchaudio as ta
+from chatterbox.tts import ChatterboxTTS
+
+if torch.cuda.is_available():
+    device = "cuda"
+elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
+
+model = ChatterboxTTS.from_pretrained(device=device)
+
+text = "{escaped_text}"
+voice_path = "{escaped_voice}"
+
+kwargs = {{"exaggeration": {exaggeration}, "cfg_weight": {cfg_weight}}}
+if voice_path:
+    kwargs["audio_prompt_path"] = voice_path
+
+wav = model.generate(text, **kwargs)
+ta.save("{output_path}", wav, model.sr)
+print("SUCCESS")
+'''
+
+    try:
+        result = subprocess.run(
+            [str(VENV_PYTHON), "-c", tts_script],
+            capture_output=True,
+            text=True,
+            timeout=600,  # 10 min — Chatterbox is slower than Kokoro
+            cwd=str(CHATTERBOX_DIR),
+        )
+        if "SUCCESS" in result.stdout:
+            return True
+        print(f"Chatterbox error: {result.stderr}")
+        return False
+    except subprocess.TimeoutExpired:
+        print("Chatterbox timed out")
+        return False
+    except Exception as e:
+        print(f"TTS error: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Chatterbox TTS renderer")
+    parser.add_argument("text", help="Text to speak")
+    parser.add_argument("-o", "--output", default="test.wav", help="Output WAV file")
+    parser.add_argument(
+        "-v",
+        "--voice",
+        default=DEFAULT_VOICE,
+        help="Reference WAV path for voice cloning (omit for default voice)",
+    )
+    parser.add_argument(
+        "--exaggeration", type=float, default=0.5, help="Emotion intensity (0.0-1.0)"
+    )
+    parser.add_argument(
+        "--cfg-weight", type=float, default=0.5, help="CFG guidance weight (0.0-1.0)"
+    )
+    args = parser.parse_args()
+
+    success = render_speech(
+        args.text,
+        Path(args.output),
+        voice=args.voice,
+        exaggeration=args.exaggeration,
+        cfg_weight=args.cfg_weight,
+    )
+    print("Success!" if success else "Failed")

--- a/mac/content_generator/helpers.py
+++ b/mac/content_generator/helpers.py
@@ -235,6 +235,52 @@ def format_headlines(headlines: list[dict], max_items: int | None = None) -> str
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _KOKORO_DIR = _PROJECT_ROOT / "mac" / "kokoro"
 _KOKORO_PYTHON = _KOKORO_DIR / ".venv" / "bin" / "python"
+_CHATTERBOX_DIR = _PROJECT_ROOT / "mac" / "chatterbox"
+_CHATTERBOX_PYTHON = _CHATTERBOX_DIR / ".venv" / "bin" / "python"
+_VOXTRAL_DIR = _PROJECT_ROOT / "mac" / "voxtral"
+_VOXTRAL_PYTHON = _VOXTRAL_DIR / ".venv" / "bin" / "python"
+
+_SUPPORTED_ENGINES = ("kokoro", "chatterbox", "voxtral")
+
+_DEFAULT_ENGINE_VOICES = {
+    "kokoro": "am_michael",
+    "chatterbox": "",          # empty = Chatterbox built-in baseline voice
+    "voxtral": "casual_male",
+}
+
+
+def resolve_engine(override: str | None = None) -> str:
+    """Pick the TTS engine. Priority: explicit override > WRIT_TTS_ENGINE env > STATION.tts_engine > kokoro."""
+    if override:
+        return override.lower()
+    env = os.environ.get("WRIT_TTS_ENGINE")
+    if env:
+        return env.strip().lower()
+    station_engine = getattr(STATION, "tts_engine", None)
+    if station_engine:
+        return str(station_engine).lower()
+    return "kokoro"
+
+
+def resolve_voice(voice: str | dict | None, engine: str) -> str:
+    """Resolve a voice spec to the per-engine voice id/path.
+
+    Accepts:
+      - str: legacy single-voice spec (treated as Kokoro voice for back-compat;
+        passed through unchanged for the active engine if it's kokoro).
+      - dict: {"kokoro": "...", "chatterbox": "...", "voxtral": "..."} — pick by engine.
+      - None: fall back to engine's built-in default.
+    """
+    if voice is None:
+        return _DEFAULT_ENGINE_VOICES.get(engine, "")
+    if isinstance(voice, dict):
+        if engine in voice and voice[engine] is not None:
+            return str(voice[engine])
+        return _DEFAULT_ENGINE_VOICES.get(engine, "")
+    # Plain string — assume legacy Kokoro voice id.
+    if engine == "kokoro":
+        return str(voice)
+    return _DEFAULT_ENGINE_VOICES.get(engine, "")
 
 
 def get_audio_duration(filepath: Path) -> float | None:
@@ -258,6 +304,8 @@ def render_kokoro(text: str, output_path: Path, voice: str = "am_michael") -> bo
         log("Kokoro venv not found")
         return False
 
+    # Subprocess runs with cwd=_KOKORO_DIR; resolve so relative paths still work.
+    output_path = Path(output_path).resolve()
     escaped_text = text.replace('\\', '\\\\').replace('"', '\\"').replace('\n', ' ')
 
     tts_script = f'''
@@ -299,6 +347,171 @@ print("SUCCESS")
     except Exception as e:
         log(f"Kokoro error: {e}")
         return False
+
+
+def render_chatterbox(
+    text: str,
+    output_path: Path,
+    voice: str = "",
+    exaggeration: float = 0.5,
+    cfg_weight: float = 0.5,
+) -> bool:
+    """Render text to speech using Resemble AI's Chatterbox.
+
+    voice is either an empty string (Chatterbox baseline voice) or a path to
+    a short reference WAV for voice cloning.
+    """
+    if not _CHATTERBOX_PYTHON.exists():
+        log("Chatterbox venv not found — run: cd mac/chatterbox && uv venv && uv pip install chatterbox-tts soundfile torch torchaudio 'setuptools<81'")
+        return False
+
+    output_path = Path(output_path).resolve()
+    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+    escaped_voice = voice.replace("\\", "\\\\").replace('"', '\\"') if voice else ""
+
+    tts_script = f'''
+import warnings
+warnings.filterwarnings("ignore")
+
+import torch
+import torchaudio as ta
+from chatterbox.tts import ChatterboxTTS
+
+if torch.cuda.is_available():
+    device = "cuda"
+elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
+
+model = ChatterboxTTS.from_pretrained(device=device)
+
+text = "{escaped_text}"
+voice_path = "{escaped_voice}"
+
+kwargs = {{"exaggeration": {exaggeration}, "cfg_weight": {cfg_weight}}}
+if voice_path:
+    kwargs["audio_prompt_path"] = voice_path
+
+wav = model.generate(text, **kwargs)
+ta.save("{output_path}", wav, model.sr)
+print("SUCCESS")
+'''
+
+    try:
+        result = subprocess.run(
+            [str(_CHATTERBOX_PYTHON), "-c", tts_script],
+            capture_output=True,
+            text=True,
+            timeout=900,
+            cwd=str(_CHATTERBOX_DIR),
+        )
+        if "SUCCESS" in result.stdout:
+            return True
+        log(f"Chatterbox failed: {result.stderr.strip().splitlines()[-1] if result.stderr.strip() else 'no stderr'}")
+        return False
+    except Exception as e:
+        log(f"Chatterbox error: {e}")
+        return False
+
+
+def render_voxtral(
+    text: str,
+    output_path: Path,
+    voice: str = "casual_male",
+    model_id: str | None = None,
+    sample_rate: int = 24000,
+) -> bool:
+    """Render text to speech using Mistral's Voxtral-4B-TTS via mlx-audio.
+
+    voice is either a preset id (casual_male, casual_female, neutral_male, ...)
+    or a path to a reference WAV for voice cloning.
+    """
+    if not _VOXTRAL_PYTHON.exists():
+        log("Voxtral venv not found — run: cd mac/voxtral && uv venv && uv pip install mlx-audio soundfile 'mistral-common[audio]'")
+        return False
+
+    chosen_model = model_id or os.environ.get(
+        "WRIT_VOXTRAL_MODEL", "mlx-community/Voxtral-4B-TTS-2603-mlx-4bit"
+    )
+
+    output_path = Path(output_path).resolve()
+    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+    escaped_voice = voice.replace("\\", "\\\\").replace('"', '\\"')
+    escaped_model = chosen_model.replace("\\", "\\\\").replace('"', '\\"')
+
+    tts_script = f'''
+import warnings
+warnings.filterwarnings("ignore")
+
+import numpy as np
+import soundfile as sf
+from mlx_audio.tts.utils import load
+
+model = load("{escaped_model}")
+
+text = "{escaped_text}"
+voice = "{escaped_voice}"
+
+segments = []
+for result in model.generate(text=text, voice=voice):
+    segments.append(np.asarray(result.audio))
+
+if not segments:
+    raise RuntimeError("Voxtral produced no audio")
+
+audio = segments[0] if len(segments) == 1 else np.concatenate(segments)
+sf.write("{output_path}", audio, {sample_rate})
+print("SUCCESS")
+'''
+
+    try:
+        result = subprocess.run(
+            [str(_VOXTRAL_PYTHON), "-c", tts_script],
+            capture_output=True,
+            text=True,
+            timeout=900,
+            cwd=str(_VOXTRAL_DIR),
+        )
+        if "SUCCESS" in result.stdout:
+            return True
+        log(f"Voxtral failed: {result.stderr.strip().splitlines()[-1] if result.stderr.strip() else 'no stderr'}")
+        return False
+    except Exception as e:
+        log(f"Voxtral error: {e}")
+        return False
+
+
+def render_speech(
+    text: str,
+    output_path: Path,
+    voice: str | dict | None = None,
+    *,
+    engine: str | None = None,
+) -> bool:
+    """Dispatch a TTS render to the active engine.
+
+    Args:
+        text: Text to speak.
+        output_path: Destination WAV.
+        voice: Either a single voice id/path (legacy) or a dict mapping
+            engine name -> voice id/path. None falls back to the engine default.
+        engine: Optional explicit engine override (else resolved from
+            WRIT_TTS_ENGINE env / station config / "kokoro").
+    """
+    eng = resolve_engine(engine)
+    if eng not in _SUPPORTED_ENGINES:
+        log(f"Unknown TTS engine '{eng}' — falling back to kokoro")
+        eng = "kokoro"
+    resolved_voice = resolve_voice(voice, eng)
+
+    if eng == "kokoro":
+        return render_kokoro(text, output_path, resolved_voice or "am_michael")
+    if eng == "chatterbox":
+        return render_chatterbox(text, output_path, resolved_voice)
+    if eng == "voxtral":
+        return render_voxtral(text, output_path, resolved_voice or "casual_male")
+    return False
 
 
 def concatenate_audio(chunk_files: list[Path], output_path: Path, gap_seconds: float = 0) -> bool:
@@ -344,13 +557,18 @@ def concatenate_audio(chunk_files: list[Path], output_path: Path, gap_seconds: f
         return False
 
 
-def render_single_voice(text: str, output_path: Path, voice: str) -> bool:
-    """Render a single-voice script to audio, chunking for long content."""
+def render_single_voice(text: str, output_path: Path, voice: str | dict | None) -> bool:
+    """Render a single-voice script to audio, chunking for long content.
+
+    Dispatches through render_speech to the configured TTS engine. `voice` can
+    be a legacy string (Kokoro voice) or a per-engine dict.
+    """
     MAX_CHUNK_WORDS = 100
     words = text.split()
+    engine = resolve_engine()
 
     if len(words) <= MAX_CHUNK_WORDS:
-        return render_kokoro(text, output_path, voice)
+        return render_speech(text, output_path, voice, engine=engine)
 
     sentences = re.split(r'(?<=[.!?])\s+', text)
 
@@ -371,9 +589,8 @@ def render_single_voice(text: str, output_path: Path, voice: str) -> bool:
     if current_chunk:
         chunks.append(' '.join(current_chunk))
 
-    log(f"  Rendering {len(chunks)} chunks with voice {voice}...")
+    log(f"  Rendering {len(chunks)} chunks via {engine} (voice: {resolve_voice(voice, engine)})...")
 
-    # Use a temp directory for chunks so the streamer doesn't consume them
     import tempfile
     tmp_dir = Path(tempfile.mkdtemp(prefix="writ_chunks_"))
 
@@ -382,7 +599,7 @@ def render_single_voice(text: str, output_path: Path, voice: str) -> bool:
     for i, chunk in enumerate(chunks):
         chunk_path = tmp_dir / f"chunk{i:03d}.wav"
         for attempt in range(2):
-            if render_kokoro(chunk, chunk_path, voice):
+            if render_speech(chunk, chunk_path, voice, engine=engine):
                 chunk_files.append(chunk_path)
                 break
             time.sleep(2)
@@ -398,7 +615,6 @@ def render_single_voice(text: str, output_path: Path, voice: str) -> bool:
         return False
 
     result = concatenate_audio(chunk_files, output_path)
-    # Clean up temp directory
     import shutil
     shutil.rmtree(tmp_dir, ignore_errors=True)
     return result

--- a/mac/content_generator/talk_generator.py
+++ b/mac/content_generator/talk_generator.py
@@ -43,7 +43,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import (
     log, preprocess_for_tts, fetch_headlines, format_headlines, run_claude,
-    render_kokoro, render_single_voice, concatenate_audio, get_audio_duration,
+    render_speech, render_single_voice, concatenate_audio, get_audio_duration,
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -1113,7 +1113,7 @@ def render_multi_voice(script: str, output_path: Path, voices: dict[str, str]) -
                 chunk_files.append(chunk_path)
         else:
             for attempt in range(2):
-                if render_kokoro(text, chunk_path, voice):
+                if render_speech(text, chunk_path, voice):
                     chunk_files.append(chunk_path)
                     break
                 time.sleep(2)

--- a/mac/schedule.py
+++ b/mac/schedule.py
@@ -116,7 +116,10 @@ class Show:
     topic_focus: str = ""
     segment_types: list[str] = field(default_factory=lambda: ["deep_dive"])
     bumper_style: str = "ambient"
-    voices: dict[str, str] = field(default_factory=dict)
+    # voices maps speaker key ("host", "guest", ...) to either:
+    #   - a single voice id string (legacy; treated as Kokoro voice)
+    #   - a per-engine dict: {"kokoro": "af_bella", "chatterbox": "./sample.wav", "voxtral": "casual_male"}
+    voices: dict[str, str | dict[str, str]] = field(default_factory=dict)
     # Legacy fields (optional, unused in the current music-forward mode)
     segment_after_tracks: int = 1
     podcasts_enabled: bool = False
@@ -163,7 +166,7 @@ class ResolvedShow:
     topic_focus: str
     segment_types: list[str]
     bumper_style: str
-    voices: dict[str, str]
+    voices: dict[str, str | dict[str, str]]
     # Legacy (kept for backward compat)
     segment_after_tracks: int = 1
     podcasts_enabled: bool = False
@@ -345,8 +348,15 @@ def load_schedule(path: Path) -> StationSchedule:
         segment_types = [str(s).strip() for s in segment_types_raw]
         bumper_style = str(cfg.get("bumper_style", "ambient")).strip()
 
-        # Voice config
-        voices = cfg.get("voices") if isinstance(cfg.get("voices"), dict) else {}
+        # Voice config: accept either a flat string per speaker (legacy Kokoro voice)
+        # or a per-engine dict {"kokoro": ..., "chatterbox": ..., "voxtral": ...}.
+        voices_raw = cfg.get("voices") if isinstance(cfg.get("voices"), dict) else {}
+        voices: dict[str, str | dict[str, str]] = {}
+        for speaker_key, value in voices_raw.items():
+            if isinstance(value, dict):
+                voices[str(speaker_key)] = {str(k): str(v) for k, v in value.items()}
+            else:
+                voices[str(speaker_key)] = str(value)
 
         # Legacy fields (optional)
         segment_after_tracks = int(cfg.get("segment_after_tracks", 1))
@@ -361,7 +371,7 @@ def load_schedule(path: Path) -> StationSchedule:
             topic_focus=topic_focus,
             segment_types=segment_types,
             bumper_style=bumper_style,
-            voices={str(k): str(v) for k, v in voices.items()},
+            voices=voices,
             segment_after_tracks=segment_after_tracks,
             podcasts_enabled=podcasts_enabled,
             music=dict(music) if music else {},

--- a/mac/station_config.py
+++ b/mac/station_config.py
@@ -72,6 +72,7 @@ class StationConfig:
     home_dir: Path
     schedule_path: Path
     public_now_playing_paths: tuple[Path, ...] = ()
+    tts_engine: str = "kokoro"
 
     @property
     def runtime_dir(self) -> Path:
@@ -147,6 +148,7 @@ class StationConfig:
             "WRIT_CALL_SIGN": self.call_sign,
             "WRIT_AGENT_KIND": self.agent.kind,
             "WRIT_AGENT_COMMAND": self.agent.command,
+            "WRIT_TTS_ENGINE_DEFAULT": self.tts_engine,
             "WRIT_OUTPUT_DIR": str(self.output_dir),
             "WRIT_RUNTIME_DIR": str(self.runtime_dir),
             "WRIT_STATION_HOME": str(self.home_dir),
@@ -302,6 +304,7 @@ def load_station_config(station_id: str | None = None, path: Path = CONFIG_PATH)
         home_dir=_expand_path(paths.get("home_dir", home_default)) or Path.home() / ".writ",
         schedule_path=_expand_path(paths.get("schedule_path", "config/schedule.yaml")) or PROJECT_ROOT / "config" / "schedule.yaml",
         public_now_playing_paths=public_paths,
+        tts_engine=str(raw.get("tts_engine", "kokoro")).lower(),
     )
 
 

--- a/mac/tts_test.py
+++ b/mac/tts_test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+WRIT-FM TTS A/B test helper.
+
+Renders the same text through one (or all) TTS engines so you can compare
+outputs side-by-side without booting any daemons.
+
+Usage:
+    uv run python mac/tts_test.py kokoro "Hello from Kokoro"
+    uv run python mac/tts_test.py chatterbox "Hello from Chatterbox" --voice samples/me.wav
+    uv run python mac/tts_test.py voxtral "Hello from Voxtral" --voice casual_female
+    uv run python mac/tts_test.py all "Compare every engine on the same line"
+
+Outputs land in output/tts-test/ as `tts-test-{engine}-{timestamp}.wav`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "mac"))
+sys.path.insert(0, str(PROJECT_ROOT / "mac" / "content_generator"))
+
+# Import the per-engine renderers directly. We deliberately bypass the dispatch
+# layer here so each --engine flag really does test that engine.
+from helpers import (  # type: ignore  # noqa: E402
+    render_kokoro,
+    render_chatterbox,
+    render_voxtral,
+    get_audio_duration,
+    log,
+)
+
+ENGINES = ("kokoro", "chatterbox", "voxtral")
+DEFAULT_OUT_DIR = PROJECT_ROOT / "output" / "tts-test"
+
+
+def render_one(engine: str, text: str, voice: str | None, out_dir: Path) -> Path | None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"tts-test-{engine}-{ts}.wav"
+
+    if engine == "kokoro":
+        ok = render_kokoro(text, out_path, voice or "am_michael")
+    elif engine == "chatterbox":
+        ok = render_chatterbox(text, out_path, voice or "")
+    elif engine == "voxtral":
+        ok = render_voxtral(text, out_path, voice or "casual_male")
+    else:
+        log(f"Unknown engine: {engine}")
+        return None
+
+    if not ok or not out_path.exists():
+        log(f"  [{engine}] FAILED")
+        return None
+
+    dur = get_audio_duration(out_path)
+    dur_str = f"{dur:.1f}s" if dur else "?"
+    log(f"  [{engine}] OK -> {out_path.relative_to(PROJECT_ROOT)} ({dur_str})")
+    return out_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="A/B test WRIT-FM TTS engines.")
+    parser.add_argument(
+        "engine",
+        choices=(*ENGINES, "all"),
+        help="Engine to render with, or 'all' for every engine.",
+    )
+    parser.add_argument("text", help="Text to speak.")
+    parser.add_argument(
+        "-v", "--voice",
+        default=None,
+        help="Engine-specific voice id or reference WAV path. Engine default if omitted.",
+    )
+    parser.add_argument(
+        "-o", "--out-dir",
+        default=str(DEFAULT_OUT_DIR),
+        help=f"Directory to write samples into (default: {DEFAULT_OUT_DIR.relative_to(PROJECT_ROOT)}).",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir).expanduser()
+    if not out_dir.is_absolute():
+        out_dir = PROJECT_ROOT / out_dir
+
+    engines = ENGINES if args.engine == "all" else (args.engine,)
+
+    successes = 0
+    for eng in engines:
+        # Don't pass a voice flag through to engines that didn't ask for it
+        # unless the user is targeting a single engine.
+        voice = args.voice if args.engine != "all" else None
+        if render_one(eng, args.text, voice, out_dir) is not None:
+            successes += 1
+
+    print()
+    log(f"Done: {successes}/{len(engines)} engine(s) rendered.")
+    return 0 if successes == len(engines) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mac/voxtral/tts.py
+++ b/mac/voxtral/tts.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+WRIT-FM Voxtral TTS Module
+
+Mistral AI's Voxtral-4B-TTS-2603 (released March 2026). 4B parameter
+multilingual TTS (9 languages), voice cloning from short reference, low latency.
+
+This module uses the MLX port (mlx-community/Voxtral-4B-TTS-2603-mlx-4bit)
+through the mlx-audio package — the native Apple Silicon path.
+
+Setup:
+    cd mac/voxtral
+    uv venv
+    uv pip install mlx-audio soundfile 'mistral-common[audio]'
+
+Usage:
+    python tts.py "Hello world" -o out.wav --voice casual_male
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+VOXTRAL_DIR = Path(__file__).parent
+VENV_PYTHON = VOXTRAL_DIR / ".venv" / "bin" / "python"
+
+# Default Voxtral MLX checkpoint. 4-bit is fastest; swap to *-mlx-bf16 for
+# higher quality at ~4x size.
+DEFAULT_MODEL = os.environ.get(
+    "WRIT_VOXTRAL_MODEL", "mlx-community/Voxtral-4B-TTS-2603-mlx-4bit"
+)
+DEFAULT_VOICE = "casual_male"
+
+# Voxtral's built-in preset voices (English unless suffixed). Use voice cloning
+# (pass a reference WAV path as --voice) to override.
+VOICES = {
+    "casual_male": "Casual male, English",
+    "casual_female": "Casual female, English",
+    "cheerful_female": "Cheerful female, English",
+    "neutral_male": "Neutral male, English",
+    "neutral_female": "Neutral female, English",
+}
+
+
+def setup_venv():
+    """Create and set up the voxtral venv if it doesn't exist."""
+    venv_dir = VOXTRAL_DIR / ".venv"
+    if not venv_dir.exists():
+        print("Setting up Voxtral venv...")
+        subprocess.run(["uv", "venv"], cwd=VOXTRAL_DIR, check=True)
+        subprocess.run(
+            ["uv", "pip", "install", "mlx-audio", "soundfile", "mistral-common[audio]"],
+            cwd=VOXTRAL_DIR,
+            check=True,
+        )
+        print("Voxtral venv ready")
+    return VENV_PYTHON.exists()
+
+
+def render_speech(
+    text: str,
+    output_path: Path,
+    voice: str = DEFAULT_VOICE,
+    model_id: str = DEFAULT_MODEL,
+    sample_rate: int = 24000,
+) -> bool:
+    """
+    Render text to speech using Voxtral TTS via MLX.
+
+    Args:
+        text: The text to speak.
+        output_path: Where to save the WAV file.
+        voice: A preset voice id (e.g. "casual_male") OR a path to a reference
+            WAV for voice cloning.
+        model_id: HF model id (defaults to the 4-bit MLX checkpoint).
+        sample_rate: Output WAV sample rate (Voxtral codec runs at 24 kHz).
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    if not VENV_PYTHON.exists():
+        if not setup_venv():
+            print("Failed to set up Voxtral venv")
+            return False
+
+    # Subprocess runs with cwd=VOXTRAL_DIR; resolve so relative paths still work.
+    output_path = Path(output_path).resolve()
+    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+    escaped_voice = voice.replace("\\", "\\\\").replace('"', '\\"')
+    escaped_model = model_id.replace("\\", "\\\\").replace('"', '\\"')
+
+    tts_script = f'''
+import warnings
+warnings.filterwarnings("ignore")
+
+import numpy as np
+import soundfile as sf
+from mlx_audio.tts.utils import load
+
+model = load("{escaped_model}")
+
+text = "{escaped_text}"
+voice = "{escaped_voice}"
+
+segments = []
+for result in model.generate(text=text, voice=voice):
+    segments.append(np.asarray(result.audio))
+
+if not segments:
+    raise RuntimeError("Voxtral produced no audio")
+
+audio = segments[0] if len(segments) == 1 else np.concatenate(segments)
+sf.write("{output_path}", audio, {sample_rate})
+print("SUCCESS")
+'''
+
+    try:
+        result = subprocess.run(
+            [str(VENV_PYTHON), "-c", tts_script],
+            capture_output=True,
+            text=True,
+            timeout=600,
+            cwd=str(VOXTRAL_DIR),
+        )
+        if "SUCCESS" in result.stdout:
+            return True
+        print(f"Voxtral error: {result.stderr}")
+        return False
+    except subprocess.TimeoutExpired:
+        print("Voxtral timed out")
+        return False
+    except Exception as e:
+        print(f"TTS error: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Voxtral TTS renderer (MLX)")
+    parser.add_argument("text", help="Text to speak")
+    parser.add_argument("-o", "--output", default="test.wav", help="Output WAV file")
+    parser.add_argument(
+        "-v", "--voice", default=DEFAULT_VOICE,
+        help="Preset voice id (casual_male, casual_female, ...) or path to a reference WAV",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help="HF model id (default: 4-bit MLX checkpoint)"
+    )
+    parser.add_argument("--list-voices", action="store_true", help="List built-in preset voices")
+    args = parser.parse_args()
+
+    if args.list_voices:
+        print("Built-in preset voices (you can also pass a reference WAV path):")
+        for vid, desc in VOICES.items():
+            print(f"  {vid}: {desc}")
+    else:
+        success = render_speech(args.text, Path(args.output), voice=args.voice, model_id=args.model)
+        print("Success!" if success else "Failed")

--- a/writ
+++ b/writ
@@ -420,6 +420,17 @@ cmd_attach() {
     else validate_component "$comp"; exec tmux attach -t "$SESSION:$(component_window "$comp")"; fi
 }
 
+cmd_tts_test() {
+    if [[ $# -lt 2 ]]; then
+        echo "Usage: writ tts-test <kokoro|chatterbox|voxtral|all> \"text\" [--voice <id-or-path>]"
+        echo "Renders the same text through one or every TTS engine."
+        echo "Outputs land in output/tts-test/."
+        exit 1
+    fi
+    cd "$PROJECT_ROOT"
+    exec uv run python mac/tts_test.py "$@"
+}
+
 cmd_generate() {
     local type="${1:-}"; shift 2>/dev/null || true
     case "$type" in
@@ -461,6 +472,7 @@ cmd_help() {
   writ logs <component> [-f]  Show logs (-f for live)
   writ attach [component]     Attach to tmux window
   writ generate <talk|music>  Generate content (foreground)
+  writ tts-test <engine> "..." Render a sample WAV via one TTS engine (kokoro|chatterbox|voxtral|all)
 
   Select station:  writ --station klod-fm start stream
   Components:      icecast  stream  tunnel  api  youtube  music-gen  operator  listener
@@ -479,6 +491,7 @@ case "$cmd" in
     logs)    cmd_logs "$@" ;;
     attach)  cmd_attach "$@" ;;
     generate) cmd_generate "$@" ;;
+    tts-test) cmd_tts_test "$@" ;;
     help|--help|-h) cmd_help ;;
     *)       err "Unknown: $cmd"; cmd_help; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

Adds two new TTS engines (Chatterbox, Voxtral) alongside the existing Kokoro integration so you can A/B all three before adopting one. Kokoro stays the default and existing config keeps working.

- **Chatterbox** (Resemble AI, 0.5B) — slower than Kokoro but supports voice cloning from a short reference WAV. MPS-accelerated on Apple Silicon.
- **Voxtral** (Mistral 4B, multilingual, March 2026) — runs through `mlx-audio` on Apple Silicon (`mlx-community/Voxtral-4B-TTS-2603-mlx-4bit` by default). 20 preset voices + voice cloning.

## What's in the diff

- `mac/chatterbox/tts.py`, `mac/voxtral/tts.py` — per-engine rendering scripts that mirror `mac/kokoro/tts.py` (separate venvs, `python -c` subprocess pattern).
- `mac/content_generator/helpers.py` — adds `render_chatterbox`, `render_voxtral`, `render_speech(...)` dispatcher, and `resolve_engine`/`resolve_voice` helpers. `render_single_voice` now dispatches through `render_speech` instead of calling Kokoro directly.
- `mac/content_generator/talk_generator.py` — swaps the direct `render_kokoro` callsite in `render_multi_voice` for `render_speech`.
- `mac/schedule.py` — `Show.voices` accepts either the legacy `host: am_michael` string or a per-engine dict `host: { kokoro: af_bella, chatterbox: ./sample.wav, voxtral: casual_male }`. Strings are still treated as Kokoro voices for back-compat.
- `mac/station_config.py` + `config/stations.yaml` — new `tts_engine: kokoro|chatterbox|voxtral` field per station. `WRIT_TTS_ENGINE` env var overrides at runtime.
- `mac/tts_test.py` + `./writ tts-test` — A/B helper: renders the same line through one or every engine into `output/tts-test/`.
- `README.md` — new TTS engines section covering install, switching, per-engine voice mapping, and the A/B command.

## Install each engine's venv

```bash
# Kokoro (existing — still the default)
cd mac/kokoro && uv venv && uv pip install kokoro soundfile && cd ../..

# Chatterbox — note the setuptools pin, see install notes below
cd mac/chatterbox && uv venv && uv pip install chatterbox-tts soundfile torch torchaudio 'setuptools<81' && cd ../..

# Voxtral — note mistral-common[audio] is required, see install notes below
cd mac/voxtral && uv venv && uv pip install mlx-audio soundfile 'mistral-common[audio]' && cd ../..
```

## Switching engines

```yaml
# config/stations.yaml
stations:
  writ-fm:
    tts_engine: chatterbox    # kokoro | chatterbox | voxtral
```

or one-off:

```bash
WRIT_TTS_ENGINE=voxtral ./writ generate talk
```

## A/B testing

```bash
./writ tts-test all "Hello from the frequency between frequencies."
./writ tts-test chatterbox "Clone my voice" --voice samples/my_voice.wav
./writ tts-test voxtral "Bonjour" --voice casual_female
# Outputs land in output/tts-test/.
```

All three engines were rendered locally during development on this Mac (Darwin 24.6.0, Apple Silicon) and produced playable WAVs.

## Apple Silicon install issues hit (documented, not papered over)

1. **Chatterbox needs `setuptools<81`.** Chatterbox's `perth` watermarker imports `pkg_resources`, which was removed in setuptools 81. With newer setuptools the watermarker silently imports as `None` and `ChatterboxTTS.__init__` raises `'NoneType' object is not callable`. Pinning `setuptools<81` fixes it; this is documented in the README, the install command, and the module docstring.
2. **Voxtral needs `mistral-common[audio]`.** Without it, `mlx_audio.tts.utils.load` errors with: `Voxtral TTS tekken tokenizers require mistral-common[audio]`. Added to the install command and README.
3. **No additional MPS shims needed.** Both engines pick up Apple Silicon's MPS automatically through their own libs (Chatterbox via `device='mps'`, Voxtral via MLX). No manual device mapping required.

## Constraints honored

- Per the existing security posture, all `subprocess` calls are list-form with `shell=False`.
- The same escape-and-`python -c` pattern as `render_kokoro` for the new engines (`\` -> `\\`, `"` -> `\"`, newlines -> spaces). Renderers also resolve `output_path` to absolute before embedding so cwd differences across engine venvs don't surprise callers.
- No daemons started during dev — only the TTS test command was invoked directly.
- Scope kept to TTS; no unrelated cleanup or refactors of existing Kokoro code beyond what the dispatcher required.

## Test plan

- [ ] `./writ tts-test all "Test line"` produces three playable WAVs in `output/tts-test/`.
- [ ] `WRIT_TTS_ENGINE=chatterbox ./writ generate talk --show midnight_signal --count 1` produces a segment.
- [ ] `WRIT_TTS_ENGINE=voxtral ./writ generate talk --show midnight_signal --count 1` produces a segment.
- [ ] Existing Kokoro-default flow still works without any config change (regression check).
- [ ] Per-engine voice mapping in `schedule.yaml` resolves correctly when a `voices.host` is upgraded from a string to a `{kokoro, chatterbox, voxtral}` dict.