### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,11 +385,11 @@ curl -sf http://localhost:8001/now-playing
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=keltokhy%2Fwrit-fm&type=timeline&logscale=&legend=top-left">
+<a href="https://star-history.dera.page/#keltokhy/writ-fm&type=timeline&logscale&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=keltokhy/writ-fm&type=timeline&theme=dark&logscale&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=keltokhy/writ-fm&type=timeline&logscale&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=keltokhy/writ-fm&type=timeline&logscale&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=keltokhy/writ-fm&type=timeline&theme=dark&logscale&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=keltokhy/writ-fm&type=timeline&logscale&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=keltokhy/writ-fm&type=timeline&logscale&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is broken because the GitHub stargazer API no longer serves the data it relied on. This change points the chart at the star-history.dera.page mirror, which uses an alternative data source that requires no API token, so the chart renders correctly again.